### PR TITLE
SPARQL Variable added

### DIFF
--- a/SPARQLBurger/SPARQLSyntaxTerms.py
+++ b/SPARQLBurger/SPARQLSyntaxTerms.py
@@ -29,6 +29,29 @@ class Prefix:
             print("Error 1 @ Prefix.get_text()")
             return ""
 
+  
+class Variable:
+    def __init__(self, variable):
+        """
+        The Variable class constructor.
+        :param variable: <str> SPARQL VARIABLE (e.g. "?ex").
+        """
+        self.variable = variable.lower()
+        
+
+    def get_text(self):
+        """
+        Generates the text for the given variable (e.g. "?s ?o ?p") 
+        :return: <str> The variable definition for SPARQL query. Returns empty string if an exception was raised.
+        """
+        try:
+            return " ?%s" % (self.variable,)
+        
+        except Exception as e:
+            print("Error 1 @ Variable.get_text()")
+            return ""
+
+
 
 class Triple:
     def __init__(self, subject, predicate, object):


### PR DESCRIPTION
Creating variables in SPARQL standards is a must. 
It is used in other functions extensively, from triples to variables in select statement. 

Added variable logic which with the same structure. 

I feel there are few error handling that can be done . I'm open to brainstorm. 