### PR TITLE
Add support for OFFSET in select queries

### DIFF
--- a/SPARQLBurger/SPARQLQueryBuilder.py
+++ b/SPARQLBurger/SPARQLQueryBuilder.py
@@ -236,7 +236,7 @@ class SPARQLQuery:
 
 
 class SPARQLSelectQuery(SPARQLQuery):
-    def __init__(self, distinct=False, limit=False, include_popular_prefixes=False, offset=0):
+    def __init__(self, distinct=False, limit=0, include_popular_prefixes=False, offset=0):
         """
         The SPARQLSelectQuery class constructor.
         :param distinct: <bool> Indicates if the select should be SELECT DISTINCT.
@@ -318,7 +318,7 @@ class SPARQLSelectQuery(SPARQLQuery):
                 query_text += "\n%s%s" % (outer_indentation, group.get_text())
 
             # Add limit if required
-            if self.limit:
+            if self.limit > 0:
                 query_text += "\nLIMIT %s" % (str(self.limit))
             
             # Add offset if required

--- a/SPARQLBurger/SPARQLQueryBuilder.py
+++ b/SPARQLBurger/SPARQLQueryBuilder.py
@@ -236,7 +236,7 @@ class SPARQLQuery:
 
 
 class SPARQLSelectQuery(SPARQLQuery):
-    def __init__(self, distinct=False, limit=False, include_popular_prefixes=False):
+    def __init__(self, distinct=False, limit=False, include_popular_prefixes=False, offset=0):
         """
         The SPARQLSelectQuery class constructor.
         :param distinct: <bool> Indicates if the select should be SELECT DISTINCT.
@@ -246,6 +246,7 @@ class SPARQLSelectQuery(SPARQLQuery):
 
         self.distinct = distinct
         self.limit = limit
+        self.offset = offset
         self.variables = []
         self.group_by = []
 
@@ -319,6 +320,11 @@ class SPARQLSelectQuery(SPARQLQuery):
             # Add limit if required
             if self.limit:
                 query_text += "\nLIMIT %s" % (str(self.limit))
+            
+            # Add offset if required
+            if self.offset > 0:
+                query_text += "\nOFFSET %s" % (str(self.offset))
+
 
             return query_text
 


### PR DESCRIPTION
This adds support for adding Offset to queries, following the same pattern as limit. 

Currently, in our code we need to retrofit this like so:
```Python
query_text = select_query.get_text()
if offset != 0:
    query_text += f"OFFSET {offset}"
```

This also adds to the tests, and adds a similar test case where limit and offset are excluded